### PR TITLE
feat: add manual snapshot capture and fix job detail image

### DIFF
--- a/backend/routers/jobs.py
+++ b/backend/routers/jobs.py
@@ -11,6 +11,7 @@ from ..models import JobCreate, JobUpdate, JobResponse, TestUrlResponse, Duratio
 from ..database import get_db, dict_from_row
 from ..services.url_tester import test_stream_url
 from ..services.duration_calculator import calculate_duration
+from ..services.image_capture import capture_image
 from ..services.maintenance import scan_job_files, cleanup_missing_captures, import_orphaned_files
 from ..services.job_state import calculate_job_state
 from ..utils import get_now, to_iso, parse_iso, ensure_timezone_aware
@@ -436,6 +437,42 @@ async def get_latest_image(job_id: int):
             raise HTTPException(status_code=404, detail="No captures found for this job")
         
         return {"file_path": row[0]}
+
+
+@router.post("/{job_id}/capture")
+async def manual_capture(job_id: int):
+    """
+    Take a manual snapshot using the job's existing stream settings.
+    Does not affect the job's scheduling state (next_scheduled_capture_at, status).
+    """
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM jobs WHERE id = ?", (job_id,))
+        row = cursor.fetchone()
+        
+        if not row:
+            raise HTTPException(status_code=404, detail="Job not found")
+        
+        job = dict_from_row(row)
+    
+    logger.info(f"Manual capture requested for job '{job['name']}' (ID: {job_id})")
+    
+    success, error_msg = capture_image(job)
+    
+    if not success:
+        raise HTTPException(status_code=500, detail=f"Capture failed: {error_msg}")
+    
+    # Update last_captured_at for display purposes only — scheduling is unaffected
+    now = get_now()
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE jobs SET last_captured_at = ?, updated_at = ? WHERE id = ?",
+            (to_iso(now), to_iso(now), job_id)
+        )
+    
+    logger.info(f"Manual capture completed for job '{job['name']}' (ID: {job_id})")
+    return {"success": True, "message": f"Manual capture completed for '{job['name']}'"}
 
 
 @router.post("/{job_id}/maintenance/scan", response_model=MaintenanceResult)

--- a/frontend/static/js/app.js
+++ b/frontend/static/js/app.js
@@ -446,7 +446,7 @@ async function showJobDetails(jobId) {
     try {
         const [job, capturesData] = await Promise.all([
             apiRequest(`/jobs/${jobId}`),
-            apiRequest('/captures/', { query: { job_id: jobId, page: 1, page_size: 1 } })
+            apiRequest('/captures/', { query: { job_id: jobId, page: 1, page_size: 1, sort_order: 'desc' } })
         ]);
         
         const modal = document.getElementById('job-details-modal');
@@ -549,9 +549,17 @@ async function showJobDetails(jobId) {
                            title="View captures">
                             ${job.capture_count}
                         </a>
+                        <button class="btn-icon" onclick="event.stopPropagation(); manualCapture(${job.id}, '${escapeHtml(job.name)}')" title="Take Snapshot" style="padding: 0.25rem;">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"></path>
+                                <circle cx="12" cy="13" r="4"></circle>
+                            </svg>
+                        </button>
                         <button class="btn-icon" onclick="event.stopPropagation(); closeModal('job-details-modal'); startMaintenance(${job.id}, '${escapeHtml(job.name)}')" title="Maintenance" style="padding: 0.25rem;">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path>
+                                <polyline points="23 4 23 10 17 10"></polyline>
+                                <polyline points="1 20 1 14 7 14"></polyline>
+                                <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path>
                             </svg>
                         </button>
                     </div>
@@ -2188,6 +2196,36 @@ window.addEventListener('beforeunload', () => {
 // ===== Maintenance Functions =====
 
 let maintenanceData = null;
+
+async function manualCapture(jobId, jobName) {
+    showConfirm(
+        `Take a manual snapshot for "${jobName}"? This will not affect the scheduled capture timing.`,
+        async (confirmed) => {
+            if (!confirmed) return;
+            
+            showNotification('Capturing snapshot...', 'info');
+            
+            try {
+                const response = await fetch(`${API_BASE}/jobs/${jobId}/capture`, {
+                    method: 'POST'
+                });
+                
+                if (!response.ok) {
+                    const err = await response.json();
+                    throw new Error(err.detail || 'Capture failed');
+                }
+                
+                showNotification('Snapshot captured successfully!', 'success');
+                
+                // Refresh job details to show updated capture count
+                await showJobDetails(jobId);
+            } catch (error) {
+                console.error('Manual capture failed:', error);
+                showNotification(`Snapshot failed: ${error.message}`, 'error');
+            }
+        }
+    );
+}
 
 async function startMaintenance(jobId, jobName) {
     showConfirm(


### PR DESCRIPTION
- Add POST /jobs/{job_id}/capture endpoint for on-demand snapshots
  - Reuses capture_image() for RTSP/HTTP capture
  - Updates capture count and last_captured_at
  - Does NOT affect next_scheduled_capture_at or job status
- Add camera icon button next to captures count in job details
  - Confirmation dialog before capture
  - Refreshes job details after successful capture
- Replace maintenance wrench icon with sync/refresh circular arrows
- Fix job details showing oldest capture instead of latest
  - Pass sort_order=desc when fetching capture for preview image

Closes #2