### PR TITLE
feat: add orphaned captures detection and cleanup

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -15,6 +15,7 @@ def get_db():
     """Context manager for database connections"""
     conn = sqlite3.connect(config.DATABASE_PATH)
     conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
     try:
         yield conn
         conn.commit()

--- a/backend/routers/captures.py
+++ b/backend/routers/captures.py
@@ -5,13 +5,17 @@ from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import FileResponse
 from typing import List, Optional
 from datetime import datetime
+from pydantic import BaseModel
 import os
+import re
+import shutil
 import logging
 
 from ..models import CaptureResponse, CaptureListResponse, CaptureDeleteRequest
 from ..database import get_db, dict_from_row
 from ..utils import get_now, to_iso, parse_iso
 from ..services.thumbnail_generator import get_thumbnail_path, has_thumbnail, delete_thumbnail
+from .. import config
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -96,6 +100,235 @@ async def list_captures(
             "page_size": page_size,
             "total_pages": total_pages
         }
+
+
+class OrphanedCleanupRequest(BaseModel):
+    folders: Optional[List[str]] = None
+    job_ids: Optional[List[int]] = None
+    delete_all: bool = False
+
+
+@router.get("/orphaned")
+async def scan_orphaned_captures():
+    """
+    Scan for orphaned captures:
+    1. Filesystem orphans: folders on disk that don't belong to any existing job
+    2. Database orphans: capture records referencing deleted jobs
+    """
+    captures_base = config.DEFAULT_CAPTURES_PATH
+    
+    with get_db() as conn:
+        cursor = conn.cursor()
+        
+        # Get all existing job IDs and their capture_paths
+        cursor.execute("SELECT id, capture_path FROM jobs")
+        jobs = {row[0]: row[1] for row in cursor.fetchall()}
+        active_job_ids = set(jobs.keys())
+        active_paths = set(jobs.values())
+        
+        # --- Database orphans: captures referencing deleted jobs ---
+        cursor.execute("""
+            SELECT c.job_id, COUNT(*) as cnt, SUM(c.file_size) as total_size
+            FROM captures c
+            LEFT JOIN jobs j ON c.job_id = j.id
+            WHERE j.id IS NULL
+            GROUP BY c.job_id
+            ORDER BY c.job_id
+        """)
+        
+        db_orphaned_groups = []
+        db_total_records = 0
+        db_total_size = 0
+        
+        for row in cursor.fetchall():
+            job_id, count, size = row[0], row[1], row[2] or 0
+            db_orphaned_groups.append({
+                "type": "database",
+                "original_job_id": job_id,
+                "original_job_name": f"Deleted Job #{job_id}",
+                "record_count": count,
+                "total_size": size
+            })
+            db_total_records += count
+            db_total_size += size
+    
+    # --- Filesystem orphans: folders with no matching job ---
+    fs_orphaned_groups = []
+    fs_total_files = 0
+    fs_total_size = 0
+    
+    if os.path.exists(captures_base):
+        for entry in os.scandir(captures_base):
+            if not entry.is_dir():
+                continue
+            
+            folder_path = entry.path
+            
+            if folder_path in active_paths:
+                continue
+            
+            folder_name = entry.name
+            match = re.match(r'^(\d+)_(.+)$', folder_name)
+            original_job_id = int(match.group(1)) if match else None
+            original_job_name = match.group(2) if match else folder_name
+            
+            if original_job_id and original_job_id in active_job_ids:
+                continue
+            
+            file_count = 0
+            folder_size = 0
+            for root, dirs, files in os.walk(folder_path):
+                for f in files:
+                    fp = os.path.join(root, f)
+                    try:
+                        file_count += 1
+                        folder_size += os.path.getsize(fp)
+                    except OSError:
+                        pass
+            
+            fs_orphaned_groups.append({
+                "type": "filesystem",
+                "folder_path": folder_path,
+                "folder_name": folder_name,
+                "original_job_id": original_job_id,
+                "original_job_name": original_job_name,
+                "file_count": file_count,
+                "total_size": folder_size
+            })
+            fs_total_files += file_count
+            fs_total_size += folder_size
+    
+    # Merge: DB orphans that also have a filesystem folder get combined
+    for db_group in db_orphaned_groups:
+        job_id = db_group['original_job_id']
+        matching_fs = next((g for g in fs_orphaned_groups if g['original_job_id'] == job_id), None)
+        if matching_fs:
+            matching_fs['type'] = 'both'
+            matching_fs['record_count'] = db_group['record_count']
+            matching_fs['db_size'] = db_group['total_size']
+            matching_fs['total_size'] += db_group['total_size']
+        # Otherwise DB-only group stands alone
+    
+    # Build final list: combined fs groups + db-only groups
+    all_groups = list(fs_orphaned_groups)
+    fs_job_ids = {g['original_job_id'] for g in fs_orphaned_groups}
+    for db_group in db_orphaned_groups:
+        if db_group['original_job_id'] not in fs_job_ids:
+            all_groups.append(db_group)
+    
+    all_groups.sort(key=lambda g: (g.get('original_job_id') is None, g.get('original_job_id') or 0))
+    
+    return {
+        "orphaned_groups": all_groups,
+        "total_fs_files": fs_total_files,
+        "total_fs_size": fs_total_size,
+        "total_db_records": db_total_records,
+        "total_db_size": db_total_size
+    }
+
+
+@router.post("/orphaned/cleanup")
+async def cleanup_orphaned_captures(request: OrphanedCleanupRequest):
+    """
+    Delete orphaned captures from disk and/or database.
+    Supports folder paths (filesystem), job_ids (database records), or delete_all.
+    """
+    captures_base = config.DEFAULT_CAPTURES_PATH
+    
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT id, capture_path FROM jobs")
+        jobs = {row[0]: row[1] for row in cursor.fetchall()}
+        active_job_ids = set(jobs.keys())
+        active_paths = set(jobs.values())
+    
+    deleted_folders = []
+    deleted_db_groups = []
+    errors = []
+    total_freed = 0
+    total_db_records_deleted = 0
+    
+    if request.delete_all:
+        scan = await scan_orphaned_captures()
+        folders_to_delete = [g['folder_path'] for g in scan['orphaned_groups'] if g.get('folder_path')]
+        db_job_ids_to_delete = [g['original_job_id'] for g in scan['orphaned_groups'] 
+                                if g['type'] in ('database', 'both') and g.get('original_job_id')]
+    else:
+        folders_to_delete = request.folders or []
+        db_job_ids_to_delete = request.job_ids or []
+    
+    # Delete filesystem folders
+    for folder_path in folders_to_delete:
+        if not folder_path.startswith(captures_base):
+            errors.append(f"{folder_path}: not under captures directory")
+            continue
+        if folder_path in active_paths:
+            errors.append(f"{folder_path}: belongs to an active job")
+            continue
+        if not os.path.exists(folder_path):
+            errors.append(f"{folder_path}: does not exist")
+            continue
+        
+        try:
+            folder_size = 0
+            for root, dirs, files in os.walk(folder_path):
+                for f in files:
+                    try:
+                        folder_size += os.path.getsize(os.path.join(root, f))
+                    except OSError:
+                        pass
+            
+            shutil.rmtree(folder_path)
+            deleted_folders.append(folder_path)
+            total_freed += folder_size
+            logger.info(f"Deleted orphaned capture folder: {folder_path}")
+        except Exception as e:
+            logger.error(f"Failed to delete orphaned folder {folder_path}: {e}")
+            errors.append(f"{folder_path}: {str(e)}")
+    
+    # Delete database orphan records
+    for job_id in db_job_ids_to_delete:
+        if job_id in active_job_ids:
+            errors.append(f"Job #{job_id}: still active, skipping")
+            continue
+        
+        try:
+            with get_db() as conn:
+                cursor = conn.cursor()
+                
+                # Delete associated files from disk first
+                cursor.execute("SELECT file_path FROM captures WHERE job_id = ?", (job_id,))
+                file_paths = [row[0] for row in cursor.fetchall()]
+                
+                for fp in file_paths:
+                    try:
+                        if os.path.exists(fp):
+                            os.remove(fp)
+                            # Also delete thumbnail
+                            delete_thumbnail(fp)
+                    except OSError:
+                        pass
+                
+                # Delete DB records
+                cursor.execute("SELECT COUNT(*) FROM captures WHERE job_id = ?", (job_id,))
+                count = cursor.fetchone()[0]
+                cursor.execute("DELETE FROM captures WHERE job_id = ?", (job_id,))
+                
+                deleted_db_groups.append(job_id)
+                total_db_records_deleted += count
+                logger.info(f"Deleted {count} orphaned DB records for job_id={job_id}")
+        except Exception as e:
+            logger.error(f"Failed to delete orphaned DB records for job {job_id}: {e}")
+            errors.append(f"Job #{job_id}: {str(e)}")
+    
+    return {
+        "deleted_folders": deleted_folders,
+        "deleted_db_job_ids": deleted_db_groups,
+        "total_folders_deleted": len(deleted_folders),
+        "total_db_records_deleted": total_db_records_deleted,
+        "total_freed": total_freed,
+        "errors": errors
+    }
 
 
 @router.get("/{capture_id}", response_model=CaptureResponse)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -51,6 +51,12 @@
             <div id="captures-view" class="view">
                 <div class="view-header">
                     <h2>Captures</h2>
+                    <button class="btn btn-secondary" onclick="scanOrphanedCaptures()">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: -2px; margin-right: 0.25rem;">
+                            <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path>
+                        </svg>
+                        Cleanup
+                    </button>
                 </div>
                 
                 <!-- Filters -->

--- a/frontend/static/js/app.js
+++ b/frontend/static/js/app.js
@@ -3027,6 +3027,188 @@ async function loadCaptures() {
     }
 }
 
+async function scanOrphanedCaptures() {
+    const modal = document.getElementById('maintenance-modal');
+    const title = document.getElementById('maintenance-title');
+    const content = document.getElementById('maintenance-content');
+    
+    title.textContent = 'Captures Cleanup';
+    content.innerHTML = `
+        <div style="text-align: center; padding: 2rem;">
+            <div style="font-size: 2rem; margin-bottom: 1rem;">🔍</div>
+            <p>Scanning for orphaned captures...</p>
+            <p style="color: var(--text-secondary); font-size: 0.875rem; margin-top: 0.5rem;">
+                Checking filesystem and database...
+            </p>
+        </div>
+    `;
+    modal.classList.add('active');
+    
+    try {
+        const data = await apiRequest('/captures/orphaned');
+        displayOrphanedResults(data);
+    } catch (error) {
+        console.error('Orphaned scan failed:', error);
+        content.innerHTML = `
+            <div style="text-align: center; padding: 2rem;">
+                <div style="font-size: 2rem; margin-bottom: 1rem;">❌</div>
+                <p style="color: var(--danger);">Failed to scan for orphaned captures</p>
+                <p style="color: var(--text-secondary); font-size: 0.875rem; margin-top: 0.5rem;">
+                    ${escapeHtml(error.message)}
+                </p>
+                <button class="btn btn-secondary" style="margin-top: 1rem;" onclick="closeMaintenance()">Close</button>
+            </div>
+        `;
+    }
+}
+
+function displayOrphanedResults(data) {
+    const content = document.getElementById('maintenance-content');
+    
+    if (!data.orphaned_groups || data.orphaned_groups.length === 0) {
+        content.innerHTML = `
+            <div style="text-align: center; padding: 2rem;">
+                <h3 style="margin-bottom: 0.5rem;">All Clean</h3>
+                <p style="color: var(--text-secondary);">
+                    No orphaned captures found. All files and records belong to active jobs.
+                </p>
+                <button class="btn btn-primary" style="margin-top: 1.5rem;" onclick="closeMaintenance()">Close</button>
+            </div>
+        `;
+        return;
+    }
+    
+    const groupsHtml = data.orphaned_groups.map(group => {
+        const typeLabel = group.type === 'both' ? 'Files + DB Records' 
+            : group.type === 'database' ? 'DB Records Only' 
+            : 'Files Only';
+        const typeBadgeColor = group.type === 'both' ? '#e74c3c' 
+            : group.type === 'database' ? '#3498db' 
+            : '#e67e22';
+        
+        let details = '';
+        if (group.type === 'filesystem') {
+            details = `${group.file_count} file${group.file_count !== 1 ? 's' : ''} on disk · ${formatBytes(group.total_size)}`;
+        } else if (group.type === 'database') {
+            details = `${group.record_count} DB record${group.record_count !== 1 ? 's' : ''}`;
+        } else {
+            details = `${group.file_count} file${group.file_count !== 1 ? 's' : ''} on disk + ${group.record_count} DB record${group.record_count !== 1 ? 's' : ''} · ${formatBytes(group.total_size - (group.db_size || 0))}`;
+        }
+        
+        // Build cleanup params based on type
+        const cleanupArg = group.type === 'filesystem' 
+            ? `'fs', '${escapeHtml(group.folder_path)}', null`
+            : group.type === 'database'
+            ? `'db', null, ${group.original_job_id}`
+            : `'both', '${escapeHtml(group.folder_path)}', ${group.original_job_id}`;
+        
+        return `
+            <div style="display: flex; align-items: center; justify-content: space-between; padding: 0.75rem; background: var(--bg-color); border-radius: 0.375rem; margin-bottom: 0.5rem;">
+                <div style="flex: 1; min-width: 0;">
+                    <div style="display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;">
+                        <strong>${escapeHtml(group.original_job_name)}</strong>
+                        <span style="font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 0.25rem; background: ${typeBadgeColor}; color: white;">${typeLabel}</span>
+                    </div>
+                    <div style="font-size: 0.85rem; color: var(--text-secondary); margin-top: 0.2rem;">
+                        ${details}
+                    </div>
+                </div>
+                <button class="btn btn-danger" style="padding: 0.3rem 0.75rem; font-size: 0.85rem; white-space: nowrap; margin-left: 0.5rem;" 
+                    onclick="deleteOrphanedGroup(${cleanupArg}, '${escapeHtml(group.original_job_name)}')">
+                    Delete
+                </button>
+            </div>
+        `;
+    }).join('');
+    
+    // Summary line
+    const summaryParts = [];
+    if (data.total_fs_files > 0) summaryParts.push(`${data.total_fs_files} files on disk (${formatBytes(data.total_fs_size)})`);
+    if (data.total_db_records > 0) summaryParts.push(`${data.total_db_records} DB records`);
+    
+    content.innerHTML = `
+        <div>
+            <div style="margin-bottom: 1rem;">
+                <strong style="color: #e67e22;">⚠ Orphaned Captures Found</strong>
+                <div style="font-size: 0.85rem; color: var(--text-secondary); margin-top: 0.25rem;">
+                    ${data.orphaned_groups.length} group${data.orphaned_groups.length > 1 ? 's' : ''} · ${summaryParts.join(' · ')}
+                </div>
+            </div>
+            <div style="max-height: 400px; overflow-y: auto;">
+                ${groupsHtml}
+            </div>
+            <div style="display: flex; justify-content: space-between; margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <button class="btn btn-secondary" onclick="closeMaintenance()">Close</button>
+                ${data.orphaned_groups.length > 1 ? `
+                    <button class="btn btn-danger" onclick="deleteAllOrphanedCaptures()">Delete All</button>
+                ` : ''}
+            </div>
+        </div>
+    `;
+}
+
+async function deleteOrphanedGroup(type, folderPath, jobId, jobName) {
+    showConfirm(
+        `Delete all orphaned captures from "${jobName}"? This will permanently remove ${type === 'database' ? 'database records' : type === 'both' ? 'files and database records' : 'files from disk'}.`,
+        async (confirmed) => {
+            if (!confirmed) return;
+            
+            try {
+                const body = {};
+                if (folderPath) body.folders = [folderPath];
+                if (jobId) body.job_ids = [jobId];
+                
+                const response = await apiRequest('/captures/orphaned/cleanup', {
+                    method: 'POST',
+                    body
+                });
+                
+                const parts = [];
+                if (response.total_folders_deleted > 0) parts.push(`${response.total_folders_deleted} folder(s)`);
+                if (response.total_db_records_deleted > 0) parts.push(`${response.total_db_records_deleted} DB records`);
+                if (response.total_freed > 0) parts.push(`${formatBytes(response.total_freed)} freed`);
+                
+                showNotification(`Cleaned up ${parts.join(', ')}`, 'success');
+                const data = await apiRequest('/captures/orphaned');
+                displayOrphanedResults(data);
+                loadCapturesPage();
+            } catch (error) {
+                console.error('Failed to delete orphaned captures:', error);
+                showNotification('Failed to delete orphaned captures', 'error');
+            }
+        }
+    );
+}
+
+async function deleteAllOrphanedCaptures() {
+    showConfirm(
+        'Delete ALL orphaned captures? This will permanently remove all orphaned files and database records.',
+        async (confirmed) => {
+            if (!confirmed) return;
+            
+            try {
+                const response = await apiRequest('/captures/orphaned/cleanup', {
+                    method: 'POST',
+                    body: { delete_all: true }
+                });
+                
+                const parts = [];
+                if (response.total_folders_deleted > 0) parts.push(`${response.total_folders_deleted} folder(s)`);
+                if (response.total_db_records_deleted > 0) parts.push(`${response.total_db_records_deleted} DB records`);
+                if (response.total_freed > 0) parts.push(`${formatBytes(response.total_freed)} freed`);
+                
+                showNotification(`Cleaned up ${parts.join(', ')}`, 'success');
+                const data = await apiRequest('/captures/orphaned');
+                displayOrphanedResults(data);
+                loadCapturesPage();
+            } catch (error) {
+                console.error('Failed to delete orphaned captures:', error);
+                showNotification('Failed to delete orphaned captures', 'error');
+            }
+        }
+    );
+}
+
 async function loadCapturesPage() {
     try {
         const query = {


### PR DESCRIPTION
Scan for and clean up two types of orphaned captures:
- Filesystem orphans: capture folders on disk with no matching job
- Database orphans: capture records referencing deleted jobs (SQLite foreign_keys was OFF, so ON DELETE CASCADE never fired)

Backend:
- GET /captures/orphaned: scans filesystem and DB, returns groups with type (filesystem/database/both), counts, and sizes
- POST /captures/orphaned/cleanup: deletes specified folders and/or DB records by job_id, with safety checks for active jobs
- Enable PRAGMA foreign_keys=ON in get_db() to prevent future orphans

Frontend:
- Cleanup button (wrench icon) in Captures view header
- Modal shows scanning state, then grouped results with type badges
- Per-group Delete and Delete All buttons with confirmation
- Captures grid refreshes after cleanup

Closes #11