### PR TITLE
Feature/stream preview

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -301,12 +301,17 @@
                 
                 <div class="form-group">
                     <label>Stream URL *</label>
-                    <input type="text" id="job_url" class="form-control" placeholder="http:// or rtsp://" required>
+                    <div style="display: flex; gap: 0.5rem; align-items: center;">
+                        <input type="text" id="job_url" class="form-control" placeholder="http:// or rtsp://" required style="flex: 1;">
+                        <button type="button" class="btn btn-secondary" onclick="testUrl()" style="white-space: nowrap; display: flex; align-items: center; gap: 0.35rem;">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                                <circle cx="12" cy="12" r="3"></circle>
+                            </svg>
+                            Preview
+                        </button>
+                    </div>
                     <input type="hidden" id="stream_type" value="http">
-                </div>
-
-                <div class="form-group">
-                    <button type="button" class="btn btn-secondary" onclick="testUrl()">Preview</button>
                     <div id="test-result" class="test-result"></div>
                 </div>
 

--- a/frontend/static/js/app.js
+++ b/frontend/static/js/app.js
@@ -595,9 +595,17 @@ async function showJobDetails(jobId) {
 
                 <div class="form-group" style="margin-bottom: 1.5rem;">
                     <label>Stream URL *</label>
-                    <input type="text" id="edit_url" class="form-control" value="${escapeHtml(job.url)}" required>
+                    <div style="display: flex; gap: 0.5rem; align-items: center;">
+                        <input type="text" id="edit_url" class="form-control" value="${escapeHtml(job.url)}" required style="flex: 1;">
+                        <button type="button" class="btn btn-secondary" onclick="previewStream('edit_url', 'edit-preview-result')" style="white-space: nowrap; display: flex; align-items: center; gap: 0.35rem;">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                                <circle cx="12" cy="12" r="3"></circle>
+                            </svg>
+                            Preview
+                        </button>
+                    </div>
                     <small style="color: var(--text-secondary);">HTTP or RTSP stream URL</small>
-                    <button type="button" class="btn btn-secondary" style="margin-top: 0.5rem;" onclick="previewStream('edit_url', 'edit-preview-result')">Preview</button>
                     <div id="edit-preview-result" class="test-result"></div>
                 </div>
 


### PR DESCRIPTION
Stream Preview

  Summary

  Adds a non-destructive "Preview" button to verify camera connectivity and framing at any time — both when creating a job and from the job detail modal on existing jobs.

  Changes

   - Renamed "Test URL" → "Preview" in the create job form
   - Added "Preview" button to the job detail/edit modal alongside the stream URL field
   - Preview button sits inline next to the URL input with an eye icon for visibility
   - Uses the existing /test-url endpoint — fetches a single frame and displays it without saving a capture
   - Refactored to a shared previewStream() function used by both forms

  Use Cases

   - Verify a camera is reachable before creating a job
   - Check if a camera was moved or the angle changed on an active job
   - Confirm connectivity after fixing a stream issue before re-enabling a job