### PR TITLE
Unify export to always-stream, remove export storage infrastructure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Create necessary directories
-RUN mkdir -p /app/data /captures /timelapses /imports /exports
+RUN mkdir -p /app/data /captures /timelapses /imports
 
 # Add build metadata
 LABEL org.opencontainers.image.title="Timelapse Manager" \

--- a/backend/app.py
+++ b/backend/app.py
@@ -81,19 +81,16 @@ async def lifespan(app: FastAPI):
     
     # Ensure required directories exist (use DB settings with config fallbacks)
     import os
-    from .services.import_service import get_import_path, get_export_path
-    for path_name, path_val in [("import", get_import_path()), ("export", get_export_path()), ("staging", config.IMPORT_STAGING_DIR)]:
+    from .services.import_service import get_import_path
+    for path_name, path_val in [("import", get_import_path()), ("staging", config.IMPORT_STAGING_DIR)]:
         try:
             os.makedirs(path_val, exist_ok=True)
         except PermissionError:
             logger.warning(f"Cannot create {path_name} directory: {path_val} (permission denied, skipping)")
     
     # Clean stale import staging directories (>2h old)
-    from .services.import_service import cleanup_stale_staging, cleanup_old_exports
+    from .services.import_service import cleanup_stale_staging
     cleanup_stale_staging()
-    
-    # Clean old export archives
-    cleanup_old_exports()
     
     # Backfill thumbnails for existing videos
     from .services.video_processor import backfill_thumbnails

--- a/backend/config.py
+++ b/backend/config.py
@@ -16,15 +16,10 @@ DATABASE_PATH = str(DATA_DIR / "timelapse-manager.db")
 DEFAULT_CAPTURES_PATH = "/captures"
 DEFAULT_VIDEOS_PATH = "/timelapses"
 DEFAULT_IMPORT_PATH = "/imports"
-DEFAULT_EXPORTS_PATH = "/exports"
 
 # Import settings
 IMPORT_STAGING_DIR = str(DATA_DIR / "import-staging")
 MAX_UPLOAD_SIZE = int(os.getenv("MAX_UPLOAD_SIZE", 10 * 1024 * 1024 * 1024))  # 10GB
-
-# Export settings — archives above this size are built to disk instead of streamed
-EXPORT_STREAM_THRESHOLD = 1 * 1024 * 1024 * 1024  # 1GB
-EXPORT_RETENTION_DAYS = 7  # Auto-cleanup exports older than this
 
 # Default naming patterns
 DEFAULT_CAPTURE_PATTERN = "{job_name}_{count}_{timestamp}"

--- a/backend/routers/import_router.py
+++ b/backend/routers/import_router.py
@@ -15,7 +15,7 @@ from ..services.import_service import (
     validate_path_within, sanitize_filename, detect_file_type,
     extract_archive, analyze_staging, browse_directory,
     execute_image_import, execute_video_import, probe_video,
-    get_import_path, get_export_path, get_captures_path, get_timelapses_path,
+    get_import_path, get_captures_path, get_timelapses_path,
     check_disk_space,
     set_staging_source, cleanup_import_source,
 )
@@ -44,9 +44,6 @@ class ExecuteRequest(BaseModel):
 
 class ImportPathSettings(BaseModel):
     import_path: str
-
-class ExportPathSettings(BaseModel):
-    export_path: str
 
 class ServerPathSettings(BaseModel):
     path: str
@@ -524,7 +521,6 @@ async def get_path_settings():
         'captures_path': get_captures_path(),
         'timelapses_path': get_timelapses_path(),
         'import_path': get_import_path(),
-        'export_path': get_export_path(),
     }
 
 
@@ -532,13 +528,12 @@ _PATH_KEYS = {
     'captures': ('captures_path', 'Captures'),
     'timelapses': ('timelapses_path', 'Timelapses'),
     'import': ('import_path', 'Import'),
-    'export': ('export_path', 'Export'),
 }
 
 
 @router.put("/settings/path/{path_type}")
 async def update_path_setting(path_type: str, settings: ServerPathSettings):
-    """Update a server path setting (captures, timelapses, import, export)."""
+    """Update a server path setting (captures, timelapses, import)."""
     from ..database import get_db
 
     if path_type not in _PATH_KEYS:

--- a/backend/routers/jobs.py
+++ b/backend/routers/jobs.py
@@ -2,12 +2,11 @@
 Jobs API endpoints
 """
 from fastapi import APIRouter, HTTPException, Query
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import StreamingResponse
 from typing import List, Optional
 import os
 import re
 import json
-import zipfile
 import logging
 import time
 from datetime import datetime
@@ -23,7 +22,6 @@ from ..services.capture_scheduler import get_scheduler
 from ..services.maintenance import scan_job_files, cleanup_missing_captures, import_orphaned_files, scan_directory
 from ..services.job_state import calculate_job_state
 from ..services.auto_builder import get_next_auto_build_at
-from ..services.import_service import get_export_path
 from ..utils import get_now, to_iso, parse_iso, ensure_timezone_aware
 from ..helpers.db_helpers import get_or_404, fetch_tags_for_jobs, set_job_tags
 from ..helpers.file_helpers import validate_writable_directory, make_relative, resolve_capture_path
@@ -620,22 +618,23 @@ def _get_export_files(job_id: int, job_name: str):
         )
         videos = cursor.fetchall()
     
-    sanitized = re.sub(r'[^\w\s-]', '', job_name).strip().replace(' ', '_')
+    sanitized = re.sub(r'[^\w -]', '', job_name.replace('\n', '').replace('\r', '')).strip().replace(' ', '_')
     prefix = f"{job_id}_{sanitized}"
     
     files = []
     total_size = 0
     
-    # Captures — preserve directory structure relative to job folder
+    # Captures -- preserve directory structure relative to job folder
     job_dir = job_dict.get('capture_path') or f"{job_id}_{job_name}"
-    abs_job_dir = resolve_capture_path(job_dir)
+    abs_job_dir = os.path.normpath(resolve_capture_path(job_dir))
     for row in captures:
-        disk_path = resolve_capture_path(row[0])
+        disk_path = os.path.normpath(resolve_capture_path(row[0]))
         if os.path.islink(disk_path) or not os.path.isfile(disk_path):
             continue
-        # Relative path from job dir (e.g., 2026/01/15/14/image.jpg)
-        if disk_path.startswith(abs_job_dir):
+        if disk_path.startswith(abs_job_dir + os.sep) or disk_path == abs_job_dir:
             rel = os.path.relpath(disk_path, abs_job_dir)
+            if '..' in rel.split(os.sep):
+                rel = os.path.basename(disk_path)
         else:
             rel = os.path.basename(disk_path)
         archive_path = f"{prefix}/captures/{rel}"
@@ -691,17 +690,12 @@ async def export_estimate(job_id: int):
         'video_count': vid_count,
         'video_size': vid_size,
         'total_size': total_size,
-        'method': 'stream' if total_size < config.EXPORT_STREAM_THRESHOLD else 'file',
     }
 
 
 @router.post("/{job_id}/export")
 async def export_job(job_id: int):
-    """Export a job as a ZIP archive.
-    
-    Small exports (<1GB) stream directly. Large exports are built to /exports
-    and return a download URL.
-    """
+    """Export a job as a streamed ZIP archive built on-the-fly."""
     with get_db() as conn:
         cursor = conn.cursor()
         job = get_or_404(cursor, "SELECT id, name FROM jobs WHERE id = ?", (job_id,), "Job not found")
@@ -712,7 +706,7 @@ async def export_job(job_id: int):
     if not files:
         raise HTTPException(status_code=404, detail="No files to export for this job")
     
-    sanitized = re.sub(r'[^\w\s-]', '', job_name).strip().replace(' ', '_')
+    sanitized = re.sub(r'[^\w -]', '', job_name.replace('\n', '').replace('\r', '')).strip().replace(' ', '_')
     ts = int(time.time())
     zip_name = f"{job_id}_{sanitized}_{ts}_export.zip"
     prefix = f"{job_id}_{sanitized}"
@@ -728,7 +722,6 @@ async def export_job(job_id: int):
     except Exception:
         safe_url = '(redacted)'
     
-    # Build job metadata JSON
     metadata = {
         'job_id': job_dict['id'],
         'name': job_dict['name'],
@@ -747,123 +740,21 @@ async def export_job(job_id: int):
     }
     metadata_json = json.dumps(metadata, indent=2)
     
-    if total_size < config.EXPORT_STREAM_THRESHOLD:
-        # Build to temp file and stream — avoids holding entire ZIP in memory
-        import tempfile
-        
-        tmp_fd, tmp_path = tempfile.mkstemp(suffix='.zip', dir=get_export_path())
-        try:
-            os.close(tmp_fd)
-            with zipfile.ZipFile(tmp_path, 'w', zipfile.ZIP_STORED) as zf:
-                zf.writestr(f"{prefix}/job.json", metadata_json)
-                for archive_path, disk_path in files:
-                    zf.write(disk_path, archive_path)
-            
-            def stream_and_cleanup():
-                try:
-                    with open(tmp_path, 'rb') as f:
-                        while chunk := f.read(8 * 1024 * 1024):
-                            yield chunk
-                finally:
-                    if os.path.exists(tmp_path):
-                        os.remove(tmp_path)
-            
-            return StreamingResponse(
-                stream_and_cleanup(),
-                media_type='application/zip',
-                headers={'Content-Disposition': f'attachment; filename="{zip_name}"'}
-            )
-        except Exception as e:
-            if os.path.exists(tmp_path):
-                os.remove(tmp_path)
-            logger.error(f"Export failed for job {job_id}: {e}", exc_info=True)
-            raise HTTPException(status_code=500, detail="Export failed")
-    else:
-        # Build to disk for large exports — persisted in /exports for download
-        export_path = os.path.join(get_export_path(), zip_name)
-        
-        try:
-            with zipfile.ZipFile(export_path, 'w', zipfile.ZIP_STORED) as zf:
-                zf.writestr(f"{prefix}/job.json", metadata_json)
-                
-                for archive_path, disk_path in files:
-                    zf.write(disk_path, archive_path)
-            
-            os.chmod(export_path, 0o644)
-            logger.info(f"Built export archive: {export_path} ({os.path.getsize(export_path)} bytes)")
-            add_event(f"Export completed for job '{job_name}'", "export", {"job_id": job_id, "file_name": zip_name})
-            
-            return {
-                'method': 'file',
-                'file_name': zip_name,
-                'file_size': os.path.getsize(export_path),
-                'download_url': f'/api/jobs/{job_id}/export/download/{zip_name}',
-            }
-        except Exception as e:
-            # Clean up partial file
-            if os.path.exists(export_path):
-                os.remove(export_path)
-            logger.error(f"Export failed for job {job_id}: {e}", exc_info=True)
-            raise HTTPException(status_code=500, detail="Export failed")
-
-
-@router.get("/{job_id}/export/download/{file_name}")
-async def download_export(job_id: int, file_name: str):
-    """Download a previously built export archive."""
-    # Sanitize file_name
-    if '/' in file_name or '\\' in file_name or '..' in file_name:
-        raise HTTPException(status_code=400, detail="Invalid file name")
+    import zipstream
+    zs = zipstream.ZipStream(compress_type=zipstream.ZIP_STORED)
+    zs.add(metadata_json.encode(), f"{prefix}/job.json")
+    for archive_path, disk_path in files:
+        zs.add_path(disk_path, archive_path)
     
-    export_path = os.path.join(get_export_path(), file_name)
+    add_event(f"Export completed for job '{job_name}'", "export", {"job_id": job_id})
     
-    if not os.path.isfile(export_path):
-        raise HTTPException(status_code=404, detail="Export file not found")
-    
-    # Verify the file belongs to this job
-    if not file_name.startswith(f"{job_id}_"):
-        raise HTTPException(status_code=403, detail="Export does not belong to this job")
-    
-    return FileResponse(
-        export_path,
+    return StreamingResponse(
+        zs,
         media_type='application/zip',
-        filename=file_name,
+        headers={
+            'Content-Disposition': f'attachment; filename="{zip_name}"',
+        }
     )
-
-
-@router.get("/exports/list")
-async def list_exports():
-    """List available export archives in /exports."""
-    exports_dir = get_export_path()
-    if not os.path.isdir(exports_dir):
-        return {'exports': []}
-    
-    exports = []
-    for entry in sorted(os.scandir(exports_dir), key=lambda e: e.stat().st_mtime, reverse=True):
-        if entry.is_file() and entry.name.endswith('.zip'):
-            stat = entry.stat()
-            exports.append({
-                'file_name': entry.name,
-                'file_size': stat.st_size,
-                'created_at': to_iso(datetime.fromtimestamp(stat.st_mtime, tz=get_now().tzinfo)),
-            })
-    
-    return {'exports': exports}
-
-
-@router.delete("/exports/{file_name}")
-async def delete_export(file_name: str):
-    """Delete an export archive."""
-    if '/' in file_name or '\\' in file_name or '..' in file_name:
-        raise HTTPException(status_code=400, detail="Invalid file name")
-    
-    export_path = os.path.join(get_export_path(), file_name)
-    
-    if not os.path.isfile(export_path):
-        raise HTTPException(status_code=404, detail="Export file not found")
-    
-    os.remove(export_path)
-    logger.info(f"Deleted export: {file_name}")
-    return {'status': 'deleted', 'file_name': file_name}
 
 
 # ── Directory Import ─────────────────────────────────────────────────────

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -130,44 +130,6 @@ async def regenerate_api_key():
         raise HTTPException(status_code=500, detail="Failed to regenerate API key")
 
 
-@router.get("/export-retention")
-async def get_export_retention():
-    """Get export retention setting (days). 0 = keep indefinitely."""
-    try:
-        with get_db() as conn:
-            cursor = conn.cursor()
-            cursor.execute("SELECT value FROM settings WHERE key = 'export_retention_days'")
-            row = cursor.fetchone()
-            days = int(row[0]) if row and row[0] is not None else config.EXPORT_RETENTION_DAYS
-            return {'export_retention_days': days}
-    except Exception as e:
-        logger.error(f"Error reading export retention: {e}")
-        return {'export_retention_days': config.EXPORT_RETENTION_DAYS}
-
-
-@router.put("/export-retention")
-async def update_export_retention(body: dict):
-    """Update export retention setting. 0 = keep indefinitely, min 1 day otherwise."""
-    days = body.get('export_retention_days')
-    if days is None or not isinstance(days, int) or days < 0:
-        raise HTTPException(status_code=400, detail="export_retention_days must be a non-negative integer")
-    try:
-        now = to_iso(get_now())
-        with get_db() as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                "INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?) "
-                "ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
-                ('export_retention_days', str(days), now)
-            )
-            conn.commit()
-        logger.info(f"Export retention updated to {days} days")
-        return {'export_retention_days': days}
-    except Exception as e:
-        logger.error(f"Error updating export retention: {e}")
-        raise HTTPException(status_code=500, detail="Failed to update export retention")
-
-
 @router.get("/naming-pattern")
 async def get_naming_pattern():
     """Get default capture naming pattern."""

--- a/backend/services/import_service.py
+++ b/backend/services/import_service.py
@@ -66,11 +66,6 @@ def get_import_path() -> str:
     return _get_setting_path('import_path', config.DEFAULT_IMPORT_PATH)
 
 
-def get_export_path() -> str:
-    """Get the configured export path from settings or default."""
-    return _get_setting_path('export_path', config.DEFAULT_EXPORTS_PATH)
-
-
 def get_captures_path() -> str:
     """Get the configured captures path from settings or default."""
     return _get_setting_path('captures_path', config.DEFAULT_CAPTURES_PATH)
@@ -84,51 +79,6 @@ def get_timelapses_path() -> str:
 def get_default_naming_pattern() -> str:
     """Get the configured default naming pattern from settings or default."""
     return _get_setting_path('default_naming_pattern', config.DEFAULT_CAPTURE_PATTERN)
-
-
-def cleanup_old_exports(max_age_days: int = None):
-    """Remove export archives older than max_age_days. 0 = keep indefinitely."""
-    if max_age_days is None:
-        # Read from DB setting, fall back to config default
-        try:
-            from ..database import get_db
-            with get_db() as conn:
-                cursor = conn.cursor()
-                cursor.execute("SELECT value FROM settings WHERE key = 'export_retention_days'")
-                row = cursor.fetchone()
-                if row and row[0] is not None:
-                    max_age_days = int(row[0])
-                else:
-                    max_age_days = config.EXPORT_RETENTION_DAYS
-        except Exception:
-            max_age_days = config.EXPORT_RETENTION_DAYS
-
-    if max_age_days == 0:
-        return 0
-
-    export_path = get_export_path()
-    if not os.path.isdir(export_path):
-        return 0
-
-    import time
-    now = time.time()
-    deleted = 0
-
-    for entry in os.scandir(export_path):
-        if not entry.is_file() or not entry.name.endswith('.zip'):
-            continue
-        age_days = (now - entry.stat().st_mtime) / 86400
-        if age_days > max_age_days:
-            try:
-                os.remove(entry.path)
-                deleted += 1
-                logger.info(f"Cleaned up old export ({age_days:.0f}d old): {entry.name}")
-            except OSError as e:
-                logger.error(f"Failed to cleanup export {entry.name}: {e}")
-
-    if deleted:
-        logger.info(f"Cleaned up {deleted} old export(s)")
-    return deleted
 
 
 def validate_path_within(path: str, allowed_prefix: str) -> str:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
       - ${PWD}/captures:/captures
       - ${PWD}/timelapses:/timelapses
       - ${PWD}/imports:/imports
-      - ${PWD}/exports:/exports
       - ${PWD}/data:/app/data
     # Security: Resource limits
     deploy:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ if [ "$CURRENT_UID" != "$PUID" ] || [ "$CURRENT_GID" != "$PGID" ]; then
 fi
 
 # Set ownership of directories (ignore errors for NFS/read-only mounts)
-chown -R "$PUID:$PGID" /app/data /captures /timelapses /imports /exports 2>/dev/null || true
+chown -R "$PUID:$PGID" /app/data /captures /timelapses /imports 2>/dev/null || true
 
 # Switch to app user and execute the command
 exec gosu "$PUID:$PGID" "$@"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -356,17 +356,6 @@
                         </div>
                     </div>
 
-                    <!-- Export Retention Section -->
-                    <div class="settings-section">
-                        <h3>Export Retention</h3>
-                        <p class="settings-description">Automatically clean up export archives older than this many days. Set to 0 to keep exports indefinitely.</p>
-                        <div style="display:flex;gap:0.75rem;align-items:center;margin-top:0.75rem;">
-                            <input type="number" id="export-retention-days" class="form-control" min="0" step="1" style="width:5rem;text-align:center;">
-                            <span style="color:var(--text-secondary);font-size:0.85rem;">days</span>
-                            <button class="btn btn-sm btn-purple" onclick="saveExportRetention()" style="margin-left:0.5rem;">Save</button>
-                        </div>
-                    </div>
-
                     <!-- Webhook Notifications Section -->
                     <div class="settings-section">
                         <h3>Webhook Notifications</h3>

--- a/frontend/static/js/app.js
+++ b/frontend/static/js/app.js
@@ -3857,7 +3857,6 @@ const _pathTypes = [
     { key: 'captures', label: 'Captures Path', apiField: 'captures_path' },
     { key: 'timelapses', label: 'Timelapses Path', apiField: 'timelapses_path' },
     { key: 'import', label: 'Import Path', apiField: 'import_path' },
-    { key: 'export', label: 'Export Path', apiField: 'export_path' },
 ];
 
 function renderPathRow(type) {
@@ -3932,37 +3931,12 @@ async function saveServerPath(type) {
     }
 }
 
-// --- Export retention setting ---
-async function loadExportRetention() {
-    try {
-        const result = await apiRequest('/settings/export-retention');
-        document.getElementById('export-retention-days').value = result.export_retention_days;
-    } catch (e) {
-        document.getElementById('export-retention-days').value = 7;
-    }
-}
-
 async function loadNamingPattern() {
     try {
         const result = await apiRequest('/settings/naming-pattern');
         document.getElementById('default-naming-pattern').value = result.naming_pattern;
     } catch (e) {
         document.getElementById('default-naming-pattern').value = '{job_name}_{count}_{timestamp}';
-    }
-}
-
-async function saveExportRetention() {
-    const input = document.getElementById('export-retention-days');
-    const days = parseInt(input.value, 10);
-    if (isNaN(days) || days < 0) {
-        showNotification('Retention must be 0 (indefinite) or a positive number of days', 'error');
-        return;
-    }
-    try {
-        await apiRequest('/settings/export-retention', { method: 'PUT', body: { export_retention_days: days } });
-        showNotification(days === 0 ? 'Export retention: keep indefinitely' : `Export retention: ${days} day${days !== 1 ? 's' : ''}`, 'success');
-    } catch (error) {
-        showNotification(error.message || 'Failed to update export retention', 'error');
     }
 }
 
@@ -4040,7 +4014,6 @@ async function showCreateJobModal() {
 
 async function exportJob(jobId, jobName) {
     try {
-        // Get estimate first
         const estimate = await apiRequest(`/jobs/${jobId}/export/estimate`);
         const totalSize = formatBytes(estimate.total_size);
         const details = [];
@@ -4052,47 +4025,29 @@ async function exportJob(jobId, jobName) {
             return;
         }
         
-        const desc = `${details.join(', ')} — estimated ${totalSize}`;
-        const msg = estimate.method === 'file'
-            ? `Export "${jobName}"? ${desc} (large export — saved to /exports)`
-            : `Export "${jobName}"? ${desc}`;
-        
         confirmAction(
-            msg,
+            `Export "${jobName}"? ${details.join(', ')} — estimated ${totalSize}`,
             async () => {
                 showNotification('Building export...', 'info');
                 try {
-                    if (estimate.method === 'stream') {
-                        // Small export — stream directly
-                        const response = await fetch(`${API_BASE}/jobs/${jobId}/export`, {
-                            method: 'POST',
-                        });
-                        if (!response.ok) {
-                            const err = await response.json().catch(() => ({ detail: 'Export failed' }));
-                            throw new Error(err.detail || 'Export failed');
-                        }
-                        const blob = await response.blob();
-                        const url = URL.createObjectURL(blob);
-                        const a = document.createElement('a');
-                        a.href = url;
-                        a.download = response.headers.get('content-disposition')?.match(/filename="(.+)"/)?.[1] || `${jobId}_export.zip`;
-                        document.body.appendChild(a);
-                        a.click();
-                        a.remove();
-                        URL.revokeObjectURL(url);
-                        showNotification('Export downloaded', 'success');
-                    } else {
-                        // Large export — built to disk
-                        const result = await apiRequest(`/jobs/${jobId}/export`, { method: 'POST' });
-                        const a = document.createElement('a');
-                        a.href = `${API_BASE}${result.download_url}`;
-                        a.download = result.file_name;
-                        document.body.appendChild(a);
-                        a.click();
-                        a.remove();
-                        showNotification(`Export ready: ${result.file_name} (${formatBytes(result.file_size)})`, 'success');
-                        refreshEventsSoon();
+                    const response = await fetch(`${API_BASE}/jobs/${jobId}/export`, {
+                        method: 'POST',
+                    });
+                    if (!response.ok) {
+                        const err = await response.json().catch(() => ({ detail: 'Export failed' }));
+                        throw new Error(err.detail || 'Export failed');
                     }
+                    const blob = await response.blob();
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = response.headers.get('content-disposition')?.match(/filename="(.+)"/)?.[1] || `${jobId}_export.zip`;
+                    document.body.appendChild(a);
+                    a.click();
+                    a.remove();
+                    URL.revokeObjectURL(url);
+                    showNotification('Export downloaded', 'success');
+                    refreshEventsSoon();
                 } catch (error) {
                     showNotification(error.message || 'Export failed', 'error');
                 }
@@ -5457,7 +5412,6 @@ async function loadSettings() {
     loadTagManager();
     loadSharedVideosList();
     loadServerPaths();
-    loadExportRetention();
     loadNamingPattern();
     
     // Load version and check for updates

--- a/requirements.in
+++ b/requirements.in
@@ -6,3 +6,4 @@ python-multipart>=0.0.12,<1.0.0
 pillow>=10.0.0,<12.0.0
 py7zr>=0.22.0,<1.0.0
 rarfile>=4.2,<5.0.0
+zipstream-ng>=1.8.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,3 +80,5 @@ watchfiles==1.1.1
     # via uvicorn
 websockets==16.0
     # via uvicorn
+zipstream-ng==1.9.0
+    # via -r requirements.in


### PR DESCRIPTION
  Unified Streaming Export

  Replaces the dual export system (small=stream, large=build-to-disk) with a single on-the-fly streaming ZIP approach. Eliminates all export storage infrastructure.

  What changed

  Backend

   - Export now streams the ZIP as it builds using zipstream-ng -- no temp files, no disk staging
   - Each source file is read from disk and piped directly into the ZIP stream in chunks
   - Removed EXPORT_STREAM_THRESHOLD, EXPORT_RETENTION_DAYS, DEFAULT_EXPORTS_PATH config
   - Removed export retention settings endpoints (GET/PUT /settings/export-retention)
   - Removed export path from server path settings
   - Removed old download, list, and delete export endpoints
   - Removed get_export_path() and cleanup_old_exports() from import_service
   - Fixed Zip Slip vulnerability: normalized paths prevent .. traversal in archive entries
   - Fixed HTTP header injection: stripped newlines/carriage returns from job name sanitization
   - Removed unused imports

  Frontend

   - Simplified exportJob() to single streaming fetch+blob download (no method branching)
   - Removed export path from _pathTypes array
   - Removed loadExportRetention() / saveExportRetention() and their UI section
   - Removed export retention settings panel from settings page

  Infrastructure

   - Removed /exports volume mount from docker-compose.yml
   - Removed /exports from Dockerfile mkdir and entrypoint.sh chown
   - Added zipstream-ng dependency

  How it works

  When a user clicks Export, the browser sends POST /api/jobs/{id}/export. The backend:

   1. Queries all captures and videos for the job
   2. Creates a zipstream.ZipStream object (no file on disk)
   3. Adds the metadata JSON and each source file path to the stream
   4. Returns a StreamingResponse with transfer-encoding: chunked

  As FastAPI/Starlette iterates the generator, zipstream-ng reads each source file from disk and emits ZIP-formatted chunks on-the-fly. The browser receives bytes progressively and
  writes to the download. No intermediate ZIP file is ever created on disk.

  If the user navigates away mid-download, the browser drops the connection, Starlette closes the generator, and streaming stops. Nothing to clean up.

  The trade-off is no Content-Length header, so the browser shows bytes downloaded without a percentage progress bar -- the same behavior as downloading multiple files from Google Drive
  or OneDrive.

  Closes #68