### PR TITLE
feat: move import button from jobs page to nav bar

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -39,6 +39,11 @@
                 <a href="/settings" data-view="settings" class="nav-link">Settings</a>
             </div>
             <div class="nav-actions">
+                <button class="nav-import-btn" onclick="showImportModal()" title="Import captures or videos">
+                    <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/>
+                    </svg>
+                </button>
                 <button class="event-bell" onclick="toggleEventPanel()" title="Event log">
                     <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="10"/>
@@ -103,13 +108,7 @@
             <div id="jobs-view" class="view">
                 <div class="view-header">
                     <h2>Jobs</h2>
-                    <div style="display:flex;gap:0.5rem;">
-                        <button class="btn compare-btn" onclick="showImportModal()">
-                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-                            Import
-                        </button>
-                        <button class="btn btn-accent" onclick="showCreateJobModal()">+ Create Job</button>
-                    </div>
+                    <button class="btn btn-accent" onclick="showCreateJobModal()">+ Create Job</button>
                 </div>
                 <div class="gallery-filters" id="job-filter-bar">
                     <input type="text" class="gallery-search" id="job-search" placeholder="Search jobs..." oninput="filterJobs()">

--- a/frontend/static/css/style.css
+++ b/frontend/static/css/style.css
@@ -567,6 +567,27 @@ body {
     gap: 0.5rem;
 }
 
+/* Import button in nav */
+.nav-import-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border: 2px solid var(--border-color);
+    border-radius: 50%;
+    background: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: color var(--transition-base), background var(--transition-base);
+    flex-shrink: 0;
+}
+
+.nav-import-btn:hover {
+    color: var(--primary-color);
+    background: var(--primary-glow);
+}
+
 /* Event bell button */
 .event-bell {
     position: relative;


### PR DESCRIPTION
Import is a universal action not specific to jobs. Moved the button to the top nav bar alongside the event bell and theme toggle for consistent access from any page. 

Minor UI change, no functionality or fix.