### PR TITLE
Fix/bug roundup

### DIFF
--- a/frontend/static/css/style.css
+++ b/frontend/static/css/style.css
@@ -1161,13 +1161,17 @@ body.detail-view-active .view.active {
 }
 
 .job-card-header {
-    margin-bottom: 1rem;
+    margin-bottom: 0.5rem;
 }
 
-.job-card-badges {
+.job-card-status-row {
     display: flex;
-    justify-content: flex-end;
+    align-items: center;
     gap: 0.4rem;
+    margin-top: 0.4rem;
+}
+
+.job-card-tags {
     margin-top: auto;
     padding-top: 0.75rem;
 }

--- a/frontend/static/js/app.js
+++ b/frontend/static/js/app.js
@@ -1036,6 +1036,10 @@ function renderJobs(jobs) {
             ${thumbnailHtml}
             <div class="job-card-header">
                 <div class="job-card-title">${escapeHtml(job.name)}</div>
+                <div class="job-card-status-row">
+                    <span class="job-status ${statusClass}">${statusLabel}</span>
+                    ${job.auto_build_enabled ? '<span class="auto-build-badge">Auto-Build</span>' : ''}
+                </div>
             </div>
             <div class="job-info">
                 <div><strong>${job.stream_type === 'device' ? 'Device:' : 'Stream URL:'}</strong> <span style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: inline-block; max-width: 250px; vertical-align: bottom;">${escapeHtml(job.stream_type === 'device' ? job.url : getStreamHost(job.url))}</span></div>
@@ -1061,11 +1065,7 @@ function renderJobs(jobs) {
                     <span class="stat-inline">${formatBytes(job.storage_size)}</span>
                 </div>
             </div>
-            <div class="job-card-badges">
-                ${job.tags && job.tags.length ? `<div class="card-tags">${job.tags.map(t => tagChipHTML(t, true)).join('')}</div>` : ''}
-                ${job.auto_build_enabled ? '<span class="auto-build-badge">Auto-Build</span>' : ''}
-                <span class="job-status ${statusClass}">${statusLabel}</span>
-            </div>
+            ${job.tags && job.tags.length ? `<div class="job-card-tags"><div class="card-tags">${job.tags.map(t => tagChipHTML(t, true)).join('')}</div></div>` : ''}
         </div>
     `;
     }).join('');

--- a/frontend/static/js/app.js
+++ b/frontend/static/js/app.js
@@ -1240,12 +1240,10 @@ function renderJobWarning(job) {
     if (job.status !== 'warning' || !job.warning_message) return '';
     return `
         <div class="info-box" style="margin-bottom: 1rem; border-left-color: var(--warning-color);">
-            <div class="info-box">
-                <div>
-                    <strong style="color: var(--warning-color);">Capture Warning</strong>
-                    <p class="mt-sm text-base">${escapeHtml(job.warning_message)}</p>
-                    <p class="mt-sm text-xs" style="opacity: 0.8;">Verify settings for the job. The job will continue attempting captures in case this is a temporary issue.</p>
-                </div>
+            <div>
+                <strong style="color: var(--warning-color);">Capture Warning</strong>
+                <p class="mt-sm text-base">${escapeHtml(job.warning_message)}</p>
+                <p class="mt-sm text-xs" style="opacity: 0.8;">Verify settings for the job. The job will continue attempting captures in case this is a temporary issue.</p>
             </div>
         </div>
     `;
@@ -1255,12 +1253,10 @@ function renderJobTimeWindow(job) {
     if (!job.time_window_enabled) return '';
     return `
         <div class="info-box" style="margin: 1rem 0;">
-            <div class="info-box">
-                <div>
-                    <strong>Time Window Enabled</strong>
-                    <p class="mt-sm text-base">Captures only happen between <strong>${job.time_window_start}</strong> and <strong>${job.time_window_end}</strong> each day.</p>
-                    ${job.time_window_start > job.time_window_end ? '<p class="mt-sm text-xs" style="opacity: 0.8;">This window spans midnight (e.g., captures from evening to early morning)</p>' : ''}
-                </div>
+            <div>
+                <strong>Time Window Enabled</strong>
+                <p class="mt-sm text-base">Captures only happen between <strong>${job.time_window_start}</strong> and <strong>${job.time_window_end}</strong> each day.</p>
+                ${job.time_window_start > job.time_window_end ? '<p class="mt-sm text-xs" style="opacity: 0.8;">This window spans midnight (e.g., captures from evening to early morning)</p>' : ''}
             </div>
         </div>
     `;

--- a/frontend/static/js/app.js
+++ b/frontend/static/js/app.js
@@ -4726,6 +4726,11 @@ async function duplicateJob(jobId) {
                     // Mount widget first, then populate
                     initCreateJobOverlay();
                     writeOverlayConfig('create-ab', overlayConfig);
+                    // Trigger preview render — writeOverlayConfig sets checkbox
+                    // programmatically which doesn't fire the change event
+                    if (overlayConfig.enabled) {
+                        fetchOverlayPreviewFromUrl('create-ab');
+                    }
                 } catch (e) { /* ignore invalid overlay config */ }
             }
         } else {


### PR DESCRIPTION
﻿ ### Fix overlay preview on duplicated jobs (#90)
 When duplicating a job with Auto Text Overlay enabled, the preview wouldn't render in the create modal until the user toggled the checkbox off and on. `writeOverlayConfig()` sets the
 checkbox programmatically which doesn't fire the `change` event — now explicitly triggers the preview fetch after writing the config.

 ### Fix time window / warning box layout (#91)
 Both `renderJobWarning()` and `renderJobTimeWindow()` had a duplicate nested `.info-box` div inside an outer `.info-box`, causing double padding and breaking the layout of subsequent
 sections (including the source row and preview button).

 ### Redesign job card layout (#92)
 Moved the status badge and auto-build badge into a new row directly under the job title for quick scanning. Tags now sit at the bottom of the card separated from the info block.

 **Before:** Status, auto-build, and tags were all crammed into one right-aligned row at the card bottom.
 **After:** Status + auto-build are immediately visible below the title; tags wrap at the bottom.