### PR TITLE
fix: remove double scrollbar on job detail view

### DIFF
--- a/frontend/static/css/style.css
+++ b/frontend/static/css/style.css
@@ -875,7 +875,6 @@ body.detail-view-active .view.active {
 
 .detail-main {
     min-width: 0;
-    overflow-y: auto;
     padding-bottom: var(--space-xl);
     padding-right: var(--space-sm);
 }


### PR DESCRIPTION
detail-view-body and detail-main both had overflow-y:auto, creating nested scrollbars. Let detail-view-body be the sole scroll container.